### PR TITLE
tools: Auto-generate commit msg from "autocommitmsg" with --message flag

### DIFF
--- a/tools/prepare-commit-msg.py
+++ b/tools/prepare-commit-msg.py
@@ -86,6 +86,19 @@ def render_template(file: str, commit_dir: str) -> None:
         f.write(contents)
 
 
+def write_auto_commit_msg(file: str, commit_dir: str) -> None:
+    with open(file, 'w') as f:
+        f.write(commit_scope(commit_dir))
+
+
+def is_auto_commit_msg(file: str) -> bool:
+    contents = current_message(file).strip()
+
+    if contents == "autocommitmsg":
+        return True
+    return False
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('file', type=str,
@@ -98,7 +111,12 @@ if __name__ == "__main__":
     pwd = os.getenv('PWD') or '/'
 
     match args.source:
-        case 'message' | 'template' | 'merge' | 'squash' | 'commit':
+        case 'template' | 'merge' | 'squash' | 'commit':
             pass
+        case 'message':
+            if is_auto_commit_msg(args.file):
+                write_auto_commit_msg(args.file, pwd)
+            else:
+                pass
         case _:
             render_template(args.file, pwd)


### PR DESCRIPTION
Helps with scriptability for large stack updates and will attempt to autowrite the commit message without needing to open up the editor.

e.g. git commit -m "autocommitmsg" -> "nano: Update to v1.2.3"