### PR TITLE
tools/heplers: fix error when not using symlinks

### DIFF
--- a/tools/helpers.bash
+++ b/tools/helpers.bash
@@ -78,11 +78,11 @@ function cpesearch() {
 # This function will only work if this script is sourced
 # by your bash shell.
 function gotoaosrepo() {
-    cd "$(dirname "$(readlink "${BASH_SOURCE[0]}")")/../" || return 1
+    cd "$(dirname "$(readlink -m "${BASH_SOURCE[0]}")")/../" || return 1
 }
 # deprecated - use gotoaerynosrepo
 function gotoserpentrepo() {
-    cd "$(dirname "$(readlink "${BASH_SOURCE[0]}")")/../" || return 1
+    cd "$(dirname "$(readlink -m "${BASH_SOURCE[0]}")")/../" || return 1
 }
 
 # Goes to the root directory of the git repository

--- a/tools/helpers.fish
+++ b/tools/helpers.fish
@@ -1,6 +1,6 @@
 #!/usr/bin/env fish
 function __aos_repo_dir
-    realpath (dirname (readlink (status -f)))/../
+    realpath (dirname (readlink -m (status -f)))/../
 end
 
 function __aos_toplevel

--- a/tools/helpers.zsh
+++ b/tools/helpers.zsh
@@ -22,13 +22,13 @@ function cpesearch() {
 # by your zsh shell.
 function gotoaosrepo() {
     SCRIPT_PATH=$functions_source[gotoaosrepo]
-    cd $(dirname $(readlink "${SCRIPT_PATH}"))/../
+    cd $(dirname $(readlink -m "${SCRIPT_PATH}"))/../
 }
 
 # Deprecated, use gotoaosrepo
 function gotoserpentrepo() {
     SCRIPT_PATH=$functions_source[gotoserpentrepo]
-    cd $(dirname $(readlink "${SCRIPT_PATH}"))/../
+    cd $(dirname $(readlink -m "${SCRIPT_PATH}"))/../
 }
 
 # Goes to the root directory of the git repository


### PR DESCRIPTION
I noticed when using fish as shell that the helpers scripts won't allow directly loading commands with source.
The reason is that `(status -f)` does not provide a valid input for `readlink`, if symlinks are not used. Adding `-m` causes `readlink` to not validate the path (which is fine, because `dirname` does).

This is quite nice since I don't need to create a symlink using fish. (I can directly add `source path-to-script/tools/helpers.fish` in the config fish).