### PR TITLE
vte: Hide most useful desktop entry

### DIFF
--- a/v/vte/stone.yaml
+++ b/v/vte/stone.yaml
@@ -48,3 +48,4 @@ install     : |
     %install_dir %(installroot)%(vendordir)%(sysconfdir)/profile.d
     mv %(installroot)%(sysconfdir)/profile.d/vte.sh %(installroot)%(vendordir)%(sysconfdir)/profile.d/10-vte.sh
     rm -frv %(installroot)%(sysconfdir)
+    echo "NoDisplay=true" >> %(installroot)/usr/share/applications/org.gnome.Vte.App.Gtk4.desktop


### PR DESCRIPTION
I propose to hide the single most important .desktop entry in the entire OS, more vital than the kernel, init, and possibly oxygen itself, clearly indispensable for proper kernel functioning, but best marked with NoDisplay=true to protect innocent users from its overwhelming power.