### PR TITLE
tools: Add gotopkg and remove deprecated command

### DIFF
--- a/tools/helpers.bash
+++ b/tools/helpers.bash
@@ -80,10 +80,6 @@ function cpesearch() {
 function gotoaosrepo() {
     cd "$(dirname "$(readlink -m "${BASH_SOURCE[0]}")")/../" || return 1
 }
-# deprecated - use gotoaerynosrepo
-function gotoserpentrepo() {
-    cd "$(dirname "$(readlink -m "${BASH_SOURCE[0]}")")/../" || return 1
-}
 
 # Goes to the root directory of the git repository
 function goroot() {
@@ -91,11 +87,30 @@ function goroot() {
 }
 
 # Push into a package directory
+function gotopkg() {
+    cd "$(git rev-parse --show-toplevel)"/*/"$1" || return 1
+}
+# Deprecated, use gotopkg
 function chpkg() {
     cd "$(git rev-parse --show-toplevel)"/*/"$1" || return 1
 }
 
 # Bash completions
+_gotopkg()
+{
+    # list of package directories we can go into
+    _list=$(ls "$(git rev-parse --show-toplevel)"/*/)
+
+    local cur
+    COMPREPLY=()
+    cur=${COMP_WORDS[COMP_CWORD]}
+
+    if [[ $COMP_CWORD -eq 1 ]] ; then
+        # set up an array with valid package dirname completions
+        readarray -t COMPREPLY < <(compgen -W "${_list}" -- "${cur}")
+        return 0
+    fi
+}
 _chpkg()
 {
     # list of package directories we can go into
@@ -112,4 +127,5 @@ _chpkg()
     fi
 }
 
+complete -F _gotopkg gotopkg
 complete -F _chpkg chpkg

--- a/tools/helpers.fish
+++ b/tools/helpers.fish
@@ -22,23 +22,22 @@ function gotoaosrepo -d "Go to the root of the AerynOS recipes repository"
     cd (__aos_repo_dir)
 end
 
-# Deprecated, use gotoasorepo
-function gotoserpentrepo -d "Go to the root of the Serpent recipes repository"
-    cd (__aos_repo_dir)
-end
-
 function goroot -d "Go to the root of the current Git repository"
     cd (__aos_toplevel)
 end
 
+function gotopkg -a package -d "Go to a package directory"
+    cd (__aos_toplevel)/*/$package
+end
+
+# Deprecated, use gotopkg
 function chpkg -a package -d "Go to a package directory"
     cd (__aos_toplevel)/*/$package
 end
 
 complete -c gotoaosrepo -f
-# Deprecated, remove later
-complete -c gotoserpentrepo -f
 complete -c goroot -f
+complete -c gotokg -f
+complete -c gotopkg -a "(path basename (__aos_toplevel)/*/*)"
 complete -c chpkg -f
 complete -c chpkg -a "(path basename (__aos_toplevel)/*/*)"
-

--- a/tools/helpers.zsh
+++ b/tools/helpers.zsh
@@ -25,24 +25,37 @@ function gotoaosrepo() {
     cd $(dirname $(readlink -m "${SCRIPT_PATH}"))/../
 }
 
-# Deprecated, use gotoaosrepo
-function gotoserpentrepo() {
-    SCRIPT_PATH=$functions_source[gotoserpentrepo]
-    cd $(dirname $(readlink -m "${SCRIPT_PATH}"))/../
-}
-
 # Goes to the root directory of the git repository
 function goroot() {
     cd $(git rev-parse --show-toplevel)
 }
 
 # Change into a package directory
+function gotopkg() {
+    cd $(git rev-parse --show-toplevel)/*/$1
+}
+# Deprecated, use gotopkg
 function chpkg() {
     cd $(git rev-parse --show-toplevel)/*/$1
 }
 
 
 # Package name completion
+_gotopkg()
+{
+    _list=$(ls $(git rev-parse --show-toplevel)/*/)
+
+    local cur prev
+    COMPREPLY=()
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    if [[ $COMP_CWORD -eq 1 ]] ; then
+        COMPREPLY=( $(compgen -W "${_list}" -- ${cur}) )
+        return 0
+    fi
+}
+
 _chpkg()
 {
     _list=$(ls $(git rev-parse --show-toplevel)/*/)
@@ -58,4 +71,5 @@ _chpkg()
     fi
 }
 
+complete -F _gotopkg gotopkg
 complete -F _chpkg chpkg


### PR DESCRIPTION
**Summary**

- Add gotopkg command and deprecate chpkg. This is done to align the script with Solus and it also solves my niggles with it about chp... automatic completion to `chpassword`.
- Remove gotoserpentpkg