### PR TITLE
Add nushell helpers to tools dir

### DIFF
--- a/tools/helpers.nu
+++ b/tools/helpers.nu
@@ -2,54 +2,64 @@ const RELEASE_MONITORING_URL = "https://release-monitoring.org/api/v2/versions/"
 const CPE_SEARCH_URL = "https://cpe-guesser.cve-search.org/search"
 const CPE_COMMON_PREFIX = "cpe:2.3:a:"
 export const AOS_REPO_PATH = path self | path dirname | path dirname
-const YAML_REQUIREMENTS = [ monitoring.yaml stone.yaml ]
+
+use std null-device
 
 # Check AerynOS package is latest in recipes repo.
 export def checkupdate [
-  package?: string@package_list
+  ...packages: string@package_list_strict
   --no-color (-C) # Don't color the status ouptut
 ]: nothing -> table {
-  try {
-    if ($package | is-not-empty) {
-      cd (
-        $AOS_REPO_PATH
-        | path join ($package | split chars | first) $package
-      )
-    }
-  } catch {
-    error make -u {msg: $"Couldn't find recipe for package ($package)" help: "There is autocomplete for existing packages you know..."}
-  }
-  
-  $YAML_REQUIREMENTS | each {|yaml_req|
-    if not ($yaml_req | path exists) {
-      error make -u {msg: $"($yaml_req) file doesn't exist" help: "You must be either in a package recipe directory, or supply a package name"}
-    }
-  }
 
-  open stone.yaml
-  | select name version
-  | str trim -c "'" | str trim -c '"'
-  | rename -c {version: current_version}
-  | update current_version {into string}
-  | insert available_version (
-    http get (
-      $RELEASE_MONITORING_URL
-      | url parse
-      | update params {
-        project_id: (open monitoring.yaml | get releases.id)
-      }
-      | url join
+  if ($packages | is-empty) {
+    print "Warning: No paramaters passed, using current directory name. Pass --help to see usage"
+    pwd | path basename
+  } else {
+    $packages
+  }
+  | each {|package|
+    (
+      $AOS_REPO_PATH
+      | path join ($package | split chars | first) $package
     )
-    | get stable_versions.0
-    | str trim -c "'" | str trim -c '"' # Strip any quotes
-    | str replace _ . # Replace any underscores with dots
-  )
-  | insert status {
-    |row| if ($row.current_version == $row.available_version) {
-      $"(if (not $no_color) {ansi green})Already using the latest version(ansi reset)"
+    | if (not ($in | path exists)) {
+      error make -u {msg: $"Couldn't find recipe dir for package '($package)'" help: "There is autocomplete for existing packages you know..."}
     } else {
-      $"(if (not $no_color) {ansi red_bold})Update available(ansi reset)"
+      $in
     }
+    | (
+      cd $in;
+      try {open stone.yaml | select name version} catch {
+        error make -u {msg: $"Couldn't find stone.yaml or it's name and version fields for package '($package)'"}
+      }
+      | str trim -c "'" | str trim -c '"'
+      | rename -c {version: current_version}
+      | update current_version {into string}
+      | insert available_version (
+        http get (
+          $RELEASE_MONITORING_URL
+          | url parse
+          | update params {
+            project_id: (
+              try {open monitoring.yaml | get releases.id} catch {
+                error make -u {msg: $"Couldn't find monitoring.yaml or it's releases.id field for package '($package)'"}
+              }
+            )
+          }
+          | url join
+        )
+        | get stable_versions.0
+        | str trim -c "'" | str trim -c '"' # Strip any quotes
+        | str replace _ . # Replace any underscores with dots
+      )
+      | insert status {
+        |row| if ($row.current_version == $row.available_version) {
+          $"(if (not $no_color) {ansi green})Already using the latest version(ansi reset)"
+        } else {
+          $"(if (not $no_color) {ansi red_bold})Update available(ansi reset)"
+        }
+      }
+    )
   }
 }
 
@@ -58,7 +68,7 @@ export def cpesearch [
   package?: string@package_list # Package name
 ]: nothing -> table {
   mut target = $package
-  if ($package | is-empty ) {
+  if ($package | is-empty) {
     print "Warning: No paramaters passed, using current directory name. Pass --help to see usage"
     $target = pwd | path basename
   }
@@ -88,7 +98,7 @@ export alias gotoserpentrepo = gotoaosrepo
 # Go to the root of current git repository
 export def --env goroot []: nothing -> nothing {
   try {
-    cd (git rev-parse --show-toplevel)
+    cd (git rev-parse --show-toplevel e> (null-device))
   } catch {
     error make -u {msg: $"Seems like you are not in a git repository"}
   }
@@ -106,11 +116,25 @@ export def --env chpkg [
 }
 
 def package_list [
+  --strict (-s) # Only return packages with monitoring and stone yaml files
 ]: nothing -> table {
   ls ($"($AOS_REPO_PATH)/?/*" | into glob)
   | where type == dir
+  | where {
+    (not $strict) or (($in.name | path join monitoring.yaml) | path exists) and (($in.name | path join stone.yaml) | path exists)
+  }
   | select name
-  | upsert description {|row| open ($row.name | path join stone.yaml) | get summary}
-  | update name {path basename}
   | rename -c {name: value}
+  | insert description {|row|
+    try { # Provide empty description if stone.yaml or it's summary field is missing
+      open ($row.value | path join stone.yaml)
+      | get summary
+    } catch { $"(ansi purple_bold)Missing (ansi s)stone.yaml(ansi rst_s) or (ansi s)summary(ansi rst_s) field!(ansi reset)" }
+  }
+  | update value {path basename}
+}
+
+ # Completer assignment (for checkupdate) neither support passing flags, nor aliases (as of nushell 0.109), which needs -s (strict) package_list function
+def package_list_strict []: nothing -> table {
+  package_list -s
 }

--- a/tools/helpers.nu
+++ b/tools/helpers.nu
@@ -7,6 +7,7 @@ const YAML_REQUIREMENTS = [ monitoring.yaml stone.yaml ]
 # Check AerynOS package is latest in recipes repo.
 export def checkupdate [
   package?: string@package_list
+  --no-color (-C) # Don't color the status ouptut
 ]: nothing -> table {
   try {
     if ($package | is-not-empty) {
@@ -45,9 +46,9 @@ export def checkupdate [
   )
   | insert status {
     |row| if ($row.current_version == $row.available_version) {
-      $"(ansi green)Already using the latest version(ansi reset)"
+      $"(if (not $no_color) {ansi green})Already using the latest version(ansi reset)"
     } else {
-      $"(ansi red_bold)Update available(ansi reset)"
+      $"(if (not $no_color) {ansi red_bold})Update available(ansi reset)"
     }
   }
 }

--- a/tools/helpers.nu
+++ b/tools/helpers.nu
@@ -1,0 +1,75 @@
+const release_monitoring_url = "https://release-monitoring.org/api/v2/versions/"
+export const AOS_REPO_PATH = path self | path dirname | path dirname
+const YAML_REQUIREMENTS = [ monitoring.yaml stone.yaml ]
+
+# Check AerynOS package is latest in recipes repo.
+export def checkupdate [] {
+
+  $YAML_REQUIREMENTS | each {|yaml_req|
+    if not ($yaml_req | path exists) {
+      error make -u {msg: $"($yaml_req) file doesn't exist" help: "Are you in the correct directory?"}
+    }
+  }
+
+  let project_data = open stone.yaml
+  | select name version
+  | str trim -c "'" | str trim -c '"'
+  | rename -c {version: current_version}
+  | merge {
+    new_version: (
+      http get (
+        $release_monitoring_url
+        | url parse
+        | update params {
+          project_id: (open monitoring.yaml | get releases.id)
+        }
+        | url join
+      )
+      | get stable_versions.0
+      | str trim -c "'" | str trim -c '"' # Strip any quotes
+      | str replace _ . # Replace any underscores with dots
+    )
+  }
+
+  print $project_data
+
+  if ($project_data.current_version == $project_data.new_version) {
+    print "Already using the latest version"
+  } else {
+    print "Update available"
+  }
+}
+
+# UNIMPLEMENTED1 PrimiTive CPE search tool
+export def cpesearch [
+  package?: string@package_list # Package name
+] {
+  mut target = $package
+  if ($package | is-empty ) {
+    print "Warning: No paramaters passed, using current directory name. Pass --help to see usage"
+    $target = pwd | path basename
+  }
+  print $"($target)"
+}
+
+# Go to the root directory of the AerynOS recipes
+export def --env gotoaosrepo [] {cd $AOS_REPO_PATH}
+# Deprecated  use gotoausrepo
+export alias gotoserpentrepo = gotoaosrepo
+
+# Push into a package directory
+export def --env chpkg [
+  package: string@package_list # Package name
+] {
+  cd ($AOS_REPO_PATH | path join ($package | split chars | first) $package)
+}
+
+def package_list [
+] {
+  ls ($"($AOS_REPO_PATH)/?/*" | into glob)
+  | where type == dir
+  | select name
+  | upsert description {|row| open ($row.name | path join stone.yaml) | get summary}
+  | update name {path basename}
+  | rename -c {name: value}
+}

--- a/tools/helpers.nu
+++ b/tools/helpers.nu
@@ -4,21 +4,17 @@ const CPE_COMMON_PREFIX = "cpe:2.3:a:"
 export const AOS_REPO_PATH = path self | path dirname | path dirname
 const YAML_REQUIREMENTS = [ monitoring.yaml stone.yaml ]
 
-use std/dirs
-
 # Check AerynOS package is latest in recipes repo.
 export def checkupdate [
   package?: string@package_list
 ]: nothing -> table {
   try {
-    dirs add (
-      if ($package | is-not-empty) {
+    if ($package | is-not-empty) {
+      cd (
         $AOS_REPO_PATH
         | path join ($package | split chars | first) $package
-      } else {
-        pwd
-      }
-    )
+      )
+    }
   } catch {
     error make -u {msg: $"Couldn't find recipe for package ($package)" help: "There is autocomplete for existing packages you know..."}
   }


### PR DESCRIPTION
I found accidentally AerynOS - nushell's package table listed that Solus has up-to-date package, and with some leapfrogging, here I am!

Yes, I've checked that nushell is up to date even in AerynOS, and now, anybody can check with `checkupdate` from nushell too.

~~I'll need to add some documentation, but there are options for usage:~~
- ~~symlink th helpers.nu to `env.NU_LIB/SCRIPT_DIR` and then use `use` or `overlay use`, case-by-case~~
- ~~or fix `use <whole_abspath_helpers.nu>` in `config nu`~~
- ~~shoul `use` be used (instead of `overlay use`) with glob import to global namespace, or without glob - in the latter case, helpers' namespace will be `helpers` which is not that great~~

~~I have an opinionated workflow (only for testing the helpers yet) that I can describe. But fish and zsh helpers aren't even documented, and last time I checked aren't even implementing everything.~~

EDIT:
The workflow is to add the repo's `tools` folder to `$env.NU_LIB_DIRS` (with `config nu`) and then use either:
- `overlay use helpers.nu`
- `use helpers.nu *`
either in `config nu` or in each terminal session you want to use the helpers

~~The cpesearch is half finished as of yet, as I had fun doing the other parts, but I wanted to share the progress anyways...~~

EDIT:
All the funcionality has been implemented in nushell idiomatic way:
- structured output where applicable
- autocompletion of packages where applicable
- correct type hinting of parameters, pipe inputs and outputs
- Doc-commenting the funtionality

Below are the screen recordings
- how to setup the env
[helpers_nu_config.webm](https://github.com/user-attachments/assets/e9ce9dc2-8e01-4059-ae18-743dd97e35d7)
- `gotoaosrepo` and `gotoserpentrepo`
[helpers_nu_goto.webm](https://github.com/user-attachments/assets/1a93a8f0-0e69-4b6e-854b-ae5bb86c2630)
- *TO BE RECORDED* `goroot` and `chpkg`
- *TO BE RECORDED* `checkupdate` and `cpsearch`

OFFTOPIC:
Can @ermo answer yet the will the installer work without XBOOTLDR? Closed the Zulip topic without explicit answer :dagger: :smile:
EDIT:
The question has been answered both here and on Zulip, thank you very much!