### PR TITLE
justfile: Replace deprecated env_var_or_default with env

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,11 +6,11 @@ default: (_build build_file)
 set dotenv-load
 set quiet
 # respect variables set in .env file next to the present justfile
-boulder := env_var_or_default('BOULDER', 'boulder')
-boulder_args := env_var_or_default('BOULDER_ARGS', '')
-boulder_profile := env_var_or_default('BOULDER_PROFILE', 'local-x86_64')
+boulder := env('BOULDER', 'boulder')
+boulder_args := env('BOULDER_ARGS', '')
+boulder_profile := env('BOULDER_PROFILE', 'local-x86_64')
 build_file := join(invocation_directory(), "stone.yaml")
-local_repo := env_var_or_default('LOCAL_REPO', '${HOME}/.cache/local_repo/x86_64')
+local_repo := env('LOCAL_REPO', '${HOME}/.cache/local_repo/x86_64')
 
 # Build the stone.yaml recipe using boulder
 _build target:


### PR DESCRIPTION
According to https://just.systems/man/en/functions.html#environment-variables, `env_var_or_default` function is deprecated.

<!--
SPDX-FileCopyrightText: 2026 AerynOS Developers
SPDX-License-Identifier: MPL-2.0
-->

**Summary**

<!-- Info on what this pull request updates/changes/etc -->

Uses `env`, which isn't deprecated.

This was pointed by my text editor, so I figured, may as well do this change to make it not point this.

**Test Plan**

<!-- Short description of how the package was tested -->

Tried to use `just` after this change.

**Checklist**

- [ ] Recipe was built and tested against the volatile stream
- [ ] This change could gainfully be highlighted in the Stream Update notes once merged
  <!-- Write an appropriate message in the Summary section -->
