### PR TITLE
Updated removals

### DIFF
--- a/removals.md
+++ b/removals.md
@@ -259,3 +259,16 @@ NB: Each entry *must* contain all sub-packages created by the package!
 
 ### Merged into libjpeg-turbo-devel
 - turbojpeg-devel
+
+### Replaced by malm
+- ferrite
+- ferrite-dbginfo
+
+### Replaced by gist
+- oxidize
+- oxidize-dbginfo
+
+### Replaced by pkgset-smia-base
+- pkgset-oxidize-mango
+- pkgset-oxidize-hypr
+- pkgset-oxidize-niri


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 AerynOS Developers
SPDX-License-Identifier: MPL-2.0
-->

**Summary**

Oxidize, Ferrite and pkgset-oxidize-* added to removals

**Test Plan**

<!-- Short description of how the package was tested -->

**Checklist**

- [x] Recipe was built and tested against the volatile stream
- [ ] This change could gainfully be highlighted in the Stream Update notes once merged
  <!-- Write an appropriate message in the Summary section -->
