### PR TITLE
greetd: Fix the missing service file

### DIFF
--- a/g/greetd/manifest.x86_64.jsonc
+++ b/g/greetd/manifest.x86_64.jsonc
@@ -17,6 +17,7 @@
 			],
 			"files": [
 				"/usr/bin/greetd",
+				"/usr/lib/systemd/system/greetd.service",
 				"/usr/share/defaults/pam.d/greetd",
 				"/usr/share/man/man1/greetd.1",
 				"/usr/share/man/man5/greetd.5",

--- a/g/greetd/stone.yaml
+++ b/g/greetd/stone.yaml
@@ -23,6 +23,7 @@ build       : |
 install     : |
     %cargo_install
     %install_file %(pkgdir)/greetd.pam %(installroot)%(vendordir)/pam.d/greetd
+    %install_file greetd.service %(installroot)%(libdir)/systemd/system/greetd.service
 
     pushd man
     %install_dir %(installroot)%(mandir)/man1


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 AerynOS Developers
SPDX-License-Identifier: MPL-2.0
-->

**Summary**

greetd was missing its service file when being installed.

**Test Plan**

I rebuilt the package, installed it and systemctl could see the service file.

**Checklist**

- [x] Recipe was built and tested against the volatile stream
- [ ] This change could gainfully be highlighted in the Stream Update notes once merged
  <!-- Write an appropriate message in the Summary section -->
