### PR TITLE
tools(update-cosmic): Add temporary workaround for COSMIC mass update

### DIFF
--- a/tools/.shuck.toml
+++ b/tools/.shuck.toml
@@ -1,0 +1,3 @@
+[format]
+indent-style = "space"
+indent-width = 2

--- a/tools/update_cosmic.sh
+++ b/tools/update_cosmic.sh
@@ -5,10 +5,8 @@
 set -e
 set -x
 
-REPO="pop-os"
-
 # The version of the cosmic desktop
-VERSION="1.0.0-alpha.7"
+VERSION="1.4.0"
 
 # Find all `stone.yaml` files that contain pop-os in the upstreams section
 # and update the upstream to the latest commit
@@ -34,14 +32,14 @@ for recipe in $(find . -name "stone.yaml"); do
       continue
     fi
 
-    # Get the latest commit from the github API
-    latest_commit=$(gh api repos/$REPO/$package_name/commits --jq '.[0].sha')
-
     # change to working directory
     pushd $(dirname $recipe)
 
     # Update the recipe
-    boulder recipe update --ver $VERSION --upstream "git|$latest_commit" --overwrite stone.yaml
+    # I HEAVILY recommend commenting it out after all the recipes related to COSMIC get updated, just so you don't bump the package twice.
+    boulder recipe update --ver $VERSION stone.yaml
+    just build
+    just mv-local
 
     popd
   fi


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 AerynOS Developers
SPDX-License-Identifier: MPL-2.0
-->

**Summary**

Fixes and adds a temporary workaround for the COSMIC mass update

**Test Plan**

The script was used for the 1.4.0 mass update of COSMIC.

**Checklist**

- [X] Recipe was built and tested against the volatile stream
- [ ] This change could gainfully be highlighted in the Stream Update notes once merged
  <!-- Write an appropriate message in the Summary section -->
