### PR TITLE
[NFC] justfile: Add the rm-local recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -125,6 +125,10 @@ ls-local: create-local
 mv-local: create-local
     cd {{ invocation_directory() }} && mv -v *.stone {{local_repo}}/ && moss index {{local_repo}}
 
+# remove .stones to LOCAL_REPO (create if it doesn't exist) and reindex it
+rm-local target: create-local
+    cd {{ invocation_directory() }} && rm -v {{local_repo}}/{{target}} && moss index {{local_repo}}
+
 # Check for upstream updates
 updates:
     cd {{ invocation_directory() }} && ent check updates

--- a/justfile
+++ b/justfile
@@ -125,7 +125,7 @@ ls-local: create-local
 mv-local: create-local
     cd {{ invocation_directory() }} && mv -v *.stone {{local_repo}}/ && moss index {{local_repo}}
 
-# remove .stones to LOCAL_REPO (create if it doesn't exist) and reindex it
+# remove individual .stones present in LOCAL_REPO (create if it doesn't exist) and reindex it.
 rm-local target: create-local
     cd {{ invocation_directory() }} && rm -v {{local_repo}}/{{target}} && moss index {{local_repo}}
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 AerynOS Developers
SPDX-License-Identifier: MPL-2.0
-->

**Summary**

Hey, first of all, I'm not sure what the commit message or the title of the PR should be, as I'm not updating the recipe.
This change introduces a new `rm-local` recipe that lets you, well, remove a recipe.
The usage is `just rm-local name-of-the-package-version.stone`

Here's an example of usage from today;
```
irevoire@tour ~/repos/aerynos/recipes 💭 % just ls-local
total 47M
-rw-r--r-- 1 2.0K Jul 28 16:12 stone.index
-rw-r--r-- 2 6.0K Jul 28 16:12 genfstab-30-1-1-x86_64.stone
-rw-r--r-- 2 6.0K Jul 28 16:12 genfstab-31-2-1-x86_64.stone
-rw-r--r-- 1 1.2M Jul 22 18:08 shfmt-3.13.1-1-1-x86_64.stone
-rw-r--r-- 1 1.3M Jul 22 18:08 shfmt-dbginfo-3.13.1-1-1-x86_64.stone
-rw-r--r-- 2  35M Jul 18 19:21 ki-dbginfo-0.0.1-snapshot-20260713-2018-dea26198a81b-1-1-x86_64.stone
-rw-r--r-- 2  11M Jul 18 19:21 ki-0.0.1-snapshot-20260713-2018-dea26198a81b-1-1-x86_64.stone
irevoire@tour ~/repos/aerynos/recipes 🐽 % just rm-local genfstab-30
rm: cannot remove '/home/irevoire/.cache/local_repo/x86_64/genfstab-30': No such file or directory
error: Recipe `rm-local` failed on line 131 with exit code 1
1 irevoire@tour ~/repos/aerynos/recipes 🦒 %
1 irevoire@tour ~/repos/aerynos/recipes 🐑 % just rm-local genfstab-30*
removed '/home/irevoire/.cache/local_repo/x86_64/genfstab-30-1-1-x86_64.stone'
Indexing 5 files

Indexed genfstab-31-2-1-x86_64.stone
Indexed shfmt-dbginfo-3.13.1-1-1-x86_64.stone
Indexed ki-0.0.1-snapshot-20260713-2018-dea26198a81b-1-1-x86_64.stone
Indexed shfmt-3.13.1-1-1-x86_64.stone
Indexed ki-dbginfo-0.0.1-snapshot-20260713-2018-dea26198a81b-1-1-x86_64.stone

Index file written to "/home/irevoire/.cache/local_repo/x86_64/stone.index"
irevoire@tour ~/repos/aerynos/recipes 🥩 % just ls-local
total 47M
-rw-r--r-- 1 2.0K Jul 28 16:33 stone.index
-rw-r--r-- 2 6.0K Jul 28 16:12 genfstab-31-2-1-x86_64.stone
-rw-r--r-- 1 1.2M Jul 22 18:08 shfmt-3.13.1-1-1-x86_64.stone
-rw-r--r-- 1 1.3M Jul 22 18:08 shfmt-dbginfo-3.13.1-1-1-x86_64.stone
-rw-r--r-- 2  35M Jul 18 19:21 ki-dbginfo-0.0.1-snapshot-20260713-2018-dea26198a81b-1-1-x86_64.stone
```

**Test Plan**

I ran the command right above :grin: 

**Checklist**

- [ ] Recipe was built and tested against the volatile stream
- [ ] This change could gainfully be highlighted in the Stream Update notes once merged
  <!-- Write an appropriate message in the Summary section -->
