### PR TITLE
[NFC] repo-wide: Add missing SPDX license headers

### DIFF
--- a/b/bazelisk/monitoring.yaml
+++ b/b/bazelisk/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 369778
   rss: https://github.com/bazelbuild/bazelisk/releases.atom

--- a/c/caligula/monitoring.yaml
+++ b/c/caligula/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 372353
   rss: https://github.com/ifd3f/caligula/releases.atom

--- a/c/cinny-desktop/monitoring.yaml
+++ b/c/cinny-desktop/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 324698
   rss: https://github.com/cinnyapp/cinny-desktop/releases.atom

--- a/c/croc/monitoring.yaml
+++ b/c/croc/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 350834
   rss: https://github.com/schollz/croc/releases.atom

--- a/d/dolphin-plugins/monitoring.yaml
+++ b/d/dolphin-plugins/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 8763
   rss: https://invent.kde.org/sdk/dolphin-plugins/-/tags?format=atom

--- a/d/dua-cli/monitoring.yaml
+++ b/d/dua-cli/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 79030
   rss: https://github.com/Byron/dua-cli/releases.atom

--- a/e/efifs/monitoring.yaml
+++ b/e/efifs/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 146162
   rss: https://github.com/pbatard/EfiFs/releases.atom

--- a/e/eigen/monitoring.yaml
+++ b/e/eigen/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 13751
   rss: https://gitlab.com/libeigen/eigen/-/tags?format=atom

--- a/e/emacs/monitoring.yaml
+++ b/e/emacs/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 675
   rss: https://github.com/emacs-mirror/emacs/releases.atom

--- a/e/envision/monitoring.yaml
+++ b/e/envision/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 375454
   rss: https://gitlab.com/gabmus/envision/-/tags?format=atom

--- a/e/evince/monitoring.yaml
+++ b/e/evince/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 8178
   rss: https://gitlab.gnome.org/GNOME/sushi/-/tags?format=atom

--- a/f/fcitx5-configtool/monitoring.yaml
+++ b/f/fcitx5-configtool/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 138233
   rss: https://github.com/fcitx/fcitx5-configtool/releases.atom

--- a/f/fcitx5-gtk/monitoring.yaml
+++ b/f/fcitx5-gtk/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 138235
   rss: https://github.com/fcitx/fcitx5-gtk/releases.atom

--- a/f/fcitx5-hangul/monitoring.yaml
+++ b/f/fcitx5-hangul/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 174360
   rss: https://github.com/fcitx/fcitx5-hangul/releases.atom

--- a/f/fcitx5-qt/monitoring.yaml
+++ b/f/fcitx5-qt/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 138234
   rss: https://github.com/fcitx/fcitx5-qt/releases.atom

--- a/f/fcitx5/monitoring.yaml
+++ b/f/fcitx5/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 138232
   rss: https://github.com/fcitx/fcitx5/releases.atom

--- a/f/ferrite/monitoring.yaml
+++ b/f/ferrite/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 389901
   rss: https://github.com/christian-bendiksen/ferrite/releases.atom

--- a/f/ffmpegthumbnailer/monitoring.yaml
+++ b/f/ffmpegthumbnailer/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 230661
   rss: https://github.com/dirkvdb/ffmpegthumbnailer/releases.atom

--- a/g/genfstab/monitoring.yaml
+++ b/g/genfstab/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 14632
   rss: https://gitlab.archlinux.org/archlinux/arch-install-scripts/-/tags?&format=atom

--- a/g/gitui/monitoring.yaml
+++ b/g/gitui/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 187553
   rss: https://github.com/gitui-org/gitui/releases.atom

--- a/g/gst-thumbnailers/monitoring.yaml
+++ b/g/gst-thumbnailers/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 387656
   rss: https://gitlab.gnome.org/GNOME/gst-thumbnailers/-/tags?format=atom

--- a/h/heroic-games-launcher/monitoring.yaml
+++ b/h/heroic-games-launcher/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 241490
   rss: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases.atom

--- a/h/hexyl/monitoring.yaml
+++ b/h/hexyl/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 18593
   rss: https://github.com/sharkdp/hexyl/releases.atom

--- a/i/imv/monitoring.yaml
+++ b/i/imv/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 93177
   rss: https://git.sr.ht/~exec64/imv/refs/rss.xml

--- a/l/libhangul/monitoring.yaml
+++ b/l/libhangul/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 1630
   rss: https://github.com/libhangul/libhangul/archive/refs/tags/releases.atom

--- a/l/libnsbmp/monitoring.yaml
+++ b/l/libnsbmp/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 7541 # https://release-monitoring.org/ and use the numeric id in the url of project
   rss: https://github.com/netsurf-browser/libnsbmp/releases.atom

--- a/l/libnsgif/monitoring.yaml
+++ b/l/libnsgif/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 7303 # https://release-monitoring.org/ and use the numeric id in the url of project
   rss: https://github.com/netsurf-browser/libnsgif/releases.atom

--- a/l/linux-gaming/README.md
+++ b/l/linux-gaming/README.md
@@ -1,1 +1,6 @@
+<!--
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+-->
+
 See ../linux-stable/README.md

--- a/m/malm/monitoring.yaml
+++ b/m/malm/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 391167
   rss: https://github.com/christian-bendiksen/malm/releases.atom

--- a/m/man-pages/monitoring.yaml
+++ b/m/man-pages/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 1883
   rss: ~

--- a/m/mangowm/README.md
+++ b/m/mangowm/README.md
@@ -1,3 +1,8 @@
+<!--
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+-->
+
 ## MangoWM maintainer's notes
 
 Remember to ensure that scenefx is up to date, as MangoWM can

--- a/m/mkvtoolnix/monitoring.yaml
+++ b/m/mkvtoolnix/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 1991
   rss: https://codeberg.org/mbunkus/mkvtoolnix/tags.rss

--- a/m/monado/monitoring.yaml
+++ b/m/monado/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 242256
   rss: https://gitlab.freedesktop.org/monado/monado/-/tags?format=atom

--- a/o/otter-launcher/monitoring.yaml
+++ b/o/otter-launcher/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 388483
   rss: https://github.com/kuokuo123/otter-launcher/releases.atom

--- a/p/permissionstests/monitoring.yaml
+++ b/p/permissionstests/monitoring.yaml
@@ -1,5 +1,8 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
 # This package will never benefit from a monitoring.yaml,
 # so please do not attempt to edit any of the fields.
+
 releases:
   id: ~
   rss: ~

--- a/p/python-mss/monitoring.yaml
+++ b/p/python-mss/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 98037
   rss: https://github.com/BoboTiG/python-mss/releases.atom

--- a/s/shfmt/monitoring.yaml
+++ b/s/shfmt/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 242179
   rss: https://github.com/mvdan/sh/releases.atom

--- a/s/steam-devices/monitoring.yaml
+++ b/s/steam-devices/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 377228
   rss: https://github.com/ValveSoftware/steam-devices/releases.atom

--- a/s/suitesparse/monitoring.yaml
+++ b/s/suitesparse/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 4908
   rss: https://github.com/DrTimothyAldenDavis/SuiteSparse/releases.atom

--- a/s/sushi/monitoring.yaml
+++ b/s/sushi/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 10897
   rss: https://gitlab.gnome.org/GNOME/sushi/-/tags?format=atom

--- a/s/systemd/README.md
+++ b/s/systemd/README.md
@@ -1,3 +1,8 @@
+<!--
+# SPDX-FileCopyrightText: 2024 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+-->
+
 ## Maintainer notes for systemd
 
 It is preferable to update systemd before doing kernel builds, if a minor systemd

--- a/t/tree-sitter/monitoring.yaml
+++ b/t/tree-sitter/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 142464
   rss: https://github.com/tree-sitter/tree-sitter/releases.atom

--- a/u/utf8cpp/monitoring.yaml
+++ b/u/utf8cpp/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 20545
   rss: https://github.com/nemtrif/utfcpp/releases.atom

--- a/w/wayvr/monitoring.yaml
+++ b/w/wayvr/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 389526
   rss: https://github.com/wayvr-org/wayvr/releases.atom

--- a/x/xr-hardware/monitoring.yaml
+++ b/x/xr-hardware/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 242258
   rss: https://gitlab.freedesktop.org/monado/utilities/xr-hardware/-/tags?format=atom

--- a/x/xrizer/monitoring.yaml
+++ b/x/xrizer/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 389528
   rss: https://github.com/Supreeeme/xrizer/releases.atom

--- a/y/yt-dlp-ejs/monitoring.yaml
+++ b/y/yt-dlp-ejs/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 386809
   rss: https://github.com/yt-dlp/ejs/releases.atom

--- a/y/yt-dlp/monitoring.yaml
+++ b/y/yt-dlp/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 143399
   rss: https://github.com/yt-dlp/yt-dlp/releases.atom

--- a/y/yubico-authenticator/monitoring.yaml
+++ b/y/yubico-authenticator/monitoring.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AerynOS Developers
+# SPDX-License-Identifier: MPL-2.0
+
 releases:
   id: 376214
   rss: https://github.com/Yubico/yubioath-flutter/releases.atom


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 AerynOS Developers
SPDX-License-Identifier: MPL-2.0
-->

**Summary**

Our REUSE compliance CI job was showing errors that multiple files in our recipes repository did not have copyright and/or licencing information.

I have done a pass based on the errors highlighted in the CI job to add the header information using the existing conventions from other files within the repository.

Hopefully this will ensure that the CI job doesn't throw out any more errors. This is also something we need to note that packagers aren't removing the headers when submitting new packages / package updates.

**Test Plan**

Not tested as this is then run as a CI job on the repo once merged

**Checklist**

- [x] Recipe was built and tested against the volatile stream
- [x] This change could gainfully be highlighted in the Stream Update notes once merged
