### PR TITLE
Packaging Policy: Clearer enforecment of process

### DIFF
--- a/PACKAGING_POLICY.md
+++ b/PACKAGING_POLICY.md
@@ -5,11 +5,11 @@
 
 | Field | Value |
 |-------|-------|
-| **Version** | 1.0 |
+| **Version** | 1.1 |
 | **Status** | Active |
 | **Owner** | aerynOS Staff |
 | **Created** | 05 Aug 2026 |
-| **Last Modified** | 05 Aug 2026 |
+| **Last Modified** | 08 Aug 2026 |
 
 This document defines the criteria for software to be an acceptable addition to the aerynOS recipes repository. All package requests will be evaluated against these criteria.
 
@@ -117,6 +117,8 @@ When a package is approved for addition to the repository, any new dependencies 
 
 For packagers, one pull request should be created for the approved package. Each new dependency introduced should be added in a separate commit within that pull request. This keeps the history clear and makes reviewing PRs easier.
 
+For clarity, packages submitted for PR that have not been approved via a [package addition request](https://github.com/aerynOS/recipes/issues/new?template=request_new_package.yaml) can be rejected or deferred until such request is made and approved.
+
 **Example Structure:**
 
 ```
@@ -156,3 +158,10 @@ Exceptions must be publicly justified when approved.
 2. If the software fails any policy criteria, the issue will be rejected with a reference to the specific section above.
 3. Approved requests will be labelled package: approved and become available for packagers to implement.
 4. Changes to this policy will be communicated through Zulip, GitHub Discussions, and blog posts.
+
+## Revision history
+
+| Version | Changelog |
+|-------|-------|
+| 1.0 | Initial policy document |
+| 1.1 | Add clarity submitting PR's without a Package Addition Request could lead to rejection of said PR |


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 AerynOS Developers
SPDX-License-Identifier: MPL-2.0
-->

### aerynOS Documentation Pull Request

#### Summary

Update Packaging Policy to v1.1

Make it clearer that for new package additions, a [package addition request](https://github.com/aerynOS/recipes/issues/new?template=request_new_package.yaml) is necessary. Not completing a Package Addition Request before submitting a PR could lead to the PR being rejected or deferred until the a Package Addition Request is made

Add a Revision History to Packaging Policy to track key changes between versions

#### Checklist

- [ ] This documentation change links back to an existing issue (link: #[issue number])
- [x] I have read and conformed to both the [Package Addition Policy](https://github.com/aerynOS/recipes/blob/main/PACKAGING_POLICY.md), and the [Contributing Guidelines](https://aerynos.dev/packaging/). I also confirm that this is my own work or properly attributed and that there are no obvious security or stability concerns or any regressions observed in this testing.
- [x] No sensitive credentials, API keys, or secrets are included in this PR
- [x] This change could gainfully be highlighted in the Stream Update notes once merged

#### Additional Context

Follow on to make a flow diagram (mermaid?) to demonstrate the process flow that contributors should use for submitting PR's of any kind

#### Screenshots / Output (if applicable)

<!-- Paste any terminal output, screenshots, or build logs that demonstrate success -->
